### PR TITLE
rename header fragment to work around concat issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -270,7 +270,7 @@ class pacman(
     replace        => true,
   }
 
-  concat::fragment{ "${pacman_config}_header":
+  concat::fragment{ "${pacman_config}_top":
     target  => $pacman_config,
     content => template('pacman/pacman.conf.erb'),
     order   => 01,


### PR DESCRIPTION
Unable to concat the pacman.conf file with latest version of concat module (a866804adb923156ab7fa15334dec67a77cec024).
Looks like an issue with the name of the first fragment, simply changing the suffix from "_header" to "_top" solves the issue.
